### PR TITLE
[ci] Add dependency between changelog and build-conan ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           path: ./build/Release/scp-machine-*.tar.gz
 
   changelog:
+    needs: build-conan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/scp-machine/blob/main/CONTRIBUTING.md)
* [ ] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add dependency between `changelog` and `build-conan` jobs in `release.yml`.
> 
>   - **CI/CD**:
>     - Add `needs: build-conan` to `changelog` job in `release.yml` to ensure it runs after `build-conan`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fscp-machine&utm_source=github&utm_medium=referral)<sup> for 4f63a50fe4d2024000df7ef14c3ee1bc4b53b043. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->