### PR TITLE
[cmake] Use ninja generator

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,7 @@
       "displayName": "Debug config (Conan)",
       "description": "Debug config with tests (Conan dependencies used)",
       "inherits": "conan-debug",
+      "generator": "Ninja",
       "installDir": "${sourceDir}/build/Debug/install",
       "cacheVariables": {
         "SC_BUILD_TESTS": true
@@ -17,7 +18,8 @@
       "displayName": "Release config (Conan)",
       "description": "Release config (Conan dependencies used)",
       "installDir": "${sourceDir}/build/Release/install",
-      "inherits": "conan-release"
+      "inherits": "conan-release",
+      "generator": "Ninja"
     },
     {
       "name": "release-with-tests-conan",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use ninja generator in cmake
 - Rename Conan remote repository url to https://conan.ostis.net/artifactory/api/conan/ostis-ai-library
 
 ### Fixed


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/scp-machine/blob/main/docs/CONTRIBUTING.md)
* [x] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch CMake generator to Ninja for debug and release configurations.
> 
>   - **CMake Configuration**:
>     - Set `generator` to `Ninja` for `debug-conan` and `release-conan` in `CMakePresets.json`.
>   - **Documentation**:
>     - Update `changelog.md` to note the use of Ninja generator in CMake.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fscp-machine&utm_source=github&utm_medium=referral)<sup> for 44c94ce82c4d04da67ed2ac8044a9bcb6ec7221c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->